### PR TITLE
feat: add Peters' test for binary outcomes and low-power caveat

### DIFF
--- a/ma-meta-analysis/assets/r/08_bias.R
+++ b/ma-meta-analysis/assets/r/08_bias.R
@@ -2,7 +2,7 @@ library(meta)
 library(metafor)
 
 # ---------------------------------------------------------------------------
-# Publication bias assessment with funnel plots on log scale + Egger's test
+# Publication bias assessment with funnel plots + asymmetry tests
 #
 # Why log scale? For ratio measures (HR, RR, OR), the funnel plot's confidence
 # region is only symmetric on the log scale. On the natural scale, the shading
@@ -10,11 +10,32 @@ library(metafor)
 #
 # backtransf = FALSE  -> x-axis shows log(HR), log(RR), or log(OR)
 # studlab = TRUE      -> label points with study names
+#
+# Test selection:
+#   - Continuous outcomes: Egger's test (linreg) — standard for SMD/MD
+#   - Binary outcomes: Peters' test preferred over Egger's, which is biased
+#     when effect size and precision are both functions of sample size
+#     (Sterne et al. 2000, PMID: 10693471; Peters et al. 2006, PMID: 16461356)
+#   - Both tests have limited power with <10 studies
+#     (Cochrane Handbook §13.3.5.2; Sterne et al. 2011, PMID: 21952616)
 # ---------------------------------------------------------------------------
+
+# Helper: build subtitle with low-power caveat when applicable
+.bias_subtitle <- function(test_label, test_result, n_studies) {
+  base <- sprintf("%s: t = %.2f, p = %.3f",
+                  test_label, test_result$statistic, test_result$p.value)
+  if (n_studies < 10) {
+    base <- paste0(base, sprintf(
+      "\nNote: limited power with %d studies (<10; Cochrane Handbook §13.3.5.2)",
+      n_studies))
+  }
+  base
+}
 
 # --- Continuous outcomes (SMD, MD) ---
 if (exists("cont_model")) {
   cont_bias <- metabias(cont_model, method.bias = "linreg")
+  n_cont <- cont_model$k
 
   # Funnel plot (continuous outcomes are already on linear scale, no log needed)
   png("figures/funnel_continuous_bias.png",
@@ -23,8 +44,7 @@ if (exists("cont_model")) {
          studlab = TRUE, cex.studlab = 0.8,
          xlab = cont_model$sm,
          col = "navy", pch = 16)
-  title(sub = sprintf("Egger's test: t = %.2f, p = %.3f",
-                       cont_bias$statistic, cont_bias$p.value),
+  title(sub = .bias_subtitle("Egger's test", cont_bias, n_cont),
         cex.sub = 0.9, col.sub = "gray40")
   dev.off()
 
@@ -46,19 +66,34 @@ if (exists("cont_model")) {
 
 # --- Binary / ratio outcomes (RR, OR, HR) ---
 if (exists("bin_model")) {
-  # Peters' test preferred for binary outcomes (lower false-positive rate)
-  bin_bias <- metabias(bin_model, method.bias = "linreg")
+  n_bin <- bin_model$k
+
+  # Egger's test (retained for comparability, but see caveat below)
+  bin_egger <- metabias(bin_model, method.bias = "linreg")
+
+  # Peters' test — recommended for binary outcomes (lower false-positive rate;
+  # Peters et al. 2006, PMID: 16461356)
+  bin_peters <- metabias(bin_model, method.bias = "peters")
 
   # Funnel plot on LOG scale -> symmetric confidence region
+  # Subtitle shows Peters' test (primary) with Egger's for reference
+  sub_text <- sprintf(
+    "Peters' test: t = %.2f, p = %.3f  |  Egger's test: t = %.2f, p = %.3f",
+    bin_peters$statistic, bin_peters$p.value,
+    bin_egger$statistic, bin_egger$p.value)
+  if (n_bin < 10) {
+    sub_text <- paste0(sub_text, sprintf(
+      "\nNote: limited power with %d studies (<10; Cochrane Handbook §13.3.5.2)",
+      n_bin))
+  }
+
   png("figures/funnel_binary_bias.png",
       width = 7, height = 6, units = "in", res = 300)
   funnel(bin_model, backtransf = FALSE,
          studlab = TRUE, cex.studlab = 0.8,
          xlab = paste0("Log ", bin_model$sm),
          col = "navy", pch = 16)
-  title(sub = sprintf("Egger's test: t = %.2f, p = %.3f",
-                       bin_bias$statistic, bin_bias$p.value),
-        cex.sub = 0.9, col.sub = "gray40")
+  title(sub = sub_text, cex.sub = 0.9, col.sub = "gray40")
   dev.off()
 
   # Contour-enhanced funnel on log scale

--- a/ma-meta-analysis/references/analysis-progress-template.md
+++ b/ma-meta-analysis/references/analysis-progress-template.md
@@ -229,7 +229,9 @@
 
 - [ ] **07**: Publication bias assessment
   - [ ] Funnel plot symmetry evaluated
-  - [ ] Egger's test performed
+  - [ ] Egger's test performed (continuous outcomes)
+  - [ ] Peters' test performed (binary outcomes — preferred over Egger's)
+  - [ ] Low-power caveat noted if <10 studies
   - [ ] Trim-and-fill analysis (if needed)
   - [ ] Interpretation documented
 


### PR DESCRIPTION
## Summary

- **Peters' test** added for binary outcomes (RR/OR/HR) as primary asymmetry test — Egger's is biased when effect size and precision both depend on sample size (Sterne et al. 2000, PMID: 10693471)
- **Egger's test** retained alongside Peters' for comparability; both shown on funnel plot subtitles
- **Low-power caveat** automatically appended when <10 studies, per Cochrane Handbook §13.3.5.2

## Changes

- `ma-meta-analysis/assets/r/08_bias.R` — core logic: run both tests for binary, helper for subtitle + caveat
- `ma-meta-analysis/references/analysis-progress-template.md` — checklist updated to reflect Peters' test and power note

## References

- Peters et al. 2006 (PMID: 16461356)
- Sterne et al. 2000 (PMID: 10693471)
- Sterne et al. 2011 (PMID: 21952616)

Closes #17

## Test plan

- [ ] Run `08_bias.R` with a binary meta-analysis model (`bin_model`) with <10 studies — verify Peters' test runs and low-power note appears
- [ ] Run with a continuous model (`cont_model`) — verify Egger's test runs as before
- [ ] Run with ≥10 studies — verify no low-power caveat appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)