### PR TITLE
Add CNMA, NMA meta-regression, and transitivity testing extensions

### DIFF
--- a/ma-agent-teams/prompts/statistician.md
+++ b/ma-agent-teams/prompts/statistician.md
@@ -38,6 +38,9 @@ Check `analysis_type.confirmed` in pico.yaml to determine which skill to follow:
 3. Generate network graph, league table, SUCRA rankings
 4. Run inconsistency diagnostics
 5. Create CINeMA GRADE assessment
+6. If combination treatments exist: run nma_11_cnma.R (CNMA extension)
+7. If covariates available: run nma_12_meta_regression.R
+8. Run nma_13_transitivity_tests.R for quantitative transitivity assessment
 
 ### Key Commands
 ```bash

--- a/ma-end-to-end/SKILL.md
+++ b/ma-end-to-end/SKILL.md
@@ -78,6 +78,10 @@ tooling/python/   # uv project
    - Route by `analysis_type.confirmed`: `pairwise` | `nma` | `pooled_proportion` | `narrative`
    - Use `/ma-meta-analysis` skill for pairwise
    - Use `/ma-network-meta-analysis` skill for NMA
+   - **NMA extensions** (run after nma_01-10 if applicable):
+     - If combination treatments exist → `nma_11_cnma.R` (Component NMA)
+     - If study-level covariates available → `nma_12_meta_regression.R`
+     - Always for NMA → `nma_13_transitivity_tests.R` (statistical transitivity assessment)
    - Write to `06_analysis/*.R`, `06_analysis/figures/*.png`, `06_analysis/tables/*.csv`, `06_analysis/renv.lock`
 7. Draft and render Quarto manuscript in `07_manuscript/`.
    - Use `/ma-manuscript-quarto` skill

--- a/ma-network-meta-analysis/assets/r/nma_01_setup.R
+++ b/ma-network-meta-analysis/assets/r/nma_01_setup.R
@@ -23,6 +23,10 @@ install.packages(c(
 
   # Sensitivity: Frequentist NMA
   "netmeta",       # Frequentist NMA (sensitivity analysis / supplement)
+                   # discomb() for CNMA, netmetareg() for meta-regression (>= 2.5)
+
+  # Advanced: Bayesian CNMA (multinma)
+  "multinma",      # Bayesian NMA with component regression (requires Stan)
 
   # Shared utilities
   "meta",          # Forest plots, pairwise helpers, pairwise()
@@ -46,6 +50,17 @@ jags_ok <- tryCatch({
 }, error = function(e) {
   warning("JAGS not found. Install from: https://mcmc-jags.sourceforge.io/")
   warning("Bayesian NMA (gemtc) requires JAGS. Falling back to netmeta only.")
+  FALSE
+})
+
+# --- 3b. Verify Stan/multinma installation (for Bayesian CNMA) ---
+multinma_ok <- tryCatch({
+  library(multinma)
+  cat("multinma version:", as.character(packageVersion("multinma")), "\n")
+  TRUE
+}, error = function(e) {
+  warning("multinma not available. Bayesian CNMA will be skipped.")
+  warning("Install: install.packages('multinma') (requires rstan or cmdstanr)")
   FALSE
 })
 
@@ -89,6 +104,8 @@ library(tidyr)
 
 cat("NMA environment setup complete.\n")
 cat("Primary: gemtc (Bayesian) | Sensitivity: netmeta (frequentist)\n")
+cat("CNMA: netmeta::discomb() (primary) | multinma (Bayesian sensitivity)\n")
 cat("gemtc version:", as.character(packageVersion("gemtc")), "\n")
 cat("netmeta version:", as.character(packageVersion("netmeta")), "\n")
 if (jags_ok) cat("JAGS: OK\n") else cat("JAGS: NOT FOUND\n")
+if (multinma_ok) cat("multinma: OK (Stan backend)\n") else cat("multinma: NOT FOUND\n")

--- a/ma-network-meta-analysis/assets/r/nma_11_cnma.R
+++ b/ma-network-meta-analysis/assets/r/nma_11_cnma.R
@@ -1,0 +1,397 @@
+# =============================================================================
+# nma_11_cnma.R — Component Network Meta-Analysis (CNMA)
+# =============================================================================
+# Purpose: Decompose combination treatments into components, test interactions,
+#          and optionally reconnect disconnected networks via additive assumption
+# Input: net_re, nma_data from nma_04_models.R
+# Output: Component effects, interaction tests, model comparisons
+# Framework: Frequentist (netmeta::discomb) PRIMARY, Bayesian (multinma) SENSITIVITY
+# Reference: Rücker et al. (2020) — Component NMA framework
+# =============================================================================
+
+source("nma_04_models.R")
+
+# =============================================================================
+# SECTION A: DATA PREPARATION FOR CNMA
+# =============================================================================
+
+cat("=== Component Network Meta-Analysis (CNMA) ===\n")
+cat("Purpose: Decompose combination treatments into individual components\n\n")
+
+# --- 1. Identify combination treatments ---
+# Combination treatments should contain "+" in their name
+# e.g., "DrugA+DrugB", "ACEI+ARB", "Chemo+Immuno"
+all_treatments <- sort(unique(c(nma_data$treat1, nma_data$treat2)))
+
+combo_treatments <- all_treatments[grepl("\\+", all_treatments)]
+single_treatments <- all_treatments[!grepl("\\+", all_treatments)]
+
+cat("All treatments:", paste(all_treatments, collapse = ", "), "\n")
+cat("Combination treatments:", paste(combo_treatments, collapse = ", "), "\n")
+cat("Single treatments:", paste(single_treatments, collapse = ", "), "\n\n")
+
+if (length(combo_treatments) == 0) {
+  cat("WARNING: No combination treatments found (no '+' in treatment names).\n")
+  cat("CNMA requires at least some combination treatments.\n")
+  cat("If your treatments are combinations, rename them with '+' separator.\n")
+  cat("Example: 'ACEI_ARB' → 'ACEI+ARB'\n")
+  cat("\nSkipping CNMA analysis.\n")
+  stop("No combination treatments found. CNMA not applicable.")
+}
+
+# --- 2. Parse components from treatment names ---
+# Extract unique components from all treatment labels
+parse_components <- function(treatment) {
+  trimws(unlist(strsplit(treatment, "\\+")))
+}
+
+all_components <- unique(unlist(lapply(all_treatments, parse_components)))
+cat("Unique components:", paste(all_components, collapse = ", "), "\n")
+cat("Number of components:", length(all_components), "\n\n")
+
+# --- 3. Create component indicator matrix ---
+# Each treatment gets a row with 1/0 for each component it contains
+component_matrix <- data.frame(
+  treatment = all_treatments,
+  stringsAsFactors = FALSE
+)
+
+for (comp in all_components) {
+  component_matrix[[comp]] <- sapply(all_treatments, function(trt) {
+    as.integer(comp %in% parse_components(trt))
+  })
+}
+
+cat("Component matrix:\n")
+print(component_matrix)
+cat("\n")
+
+# --- 4. Define inactive treatment (reference) ---
+# Typically "placebo", "control", or the treatment with fewest components
+# Adapt this to your data:
+inactive_treatment <- NULL
+
+# Auto-detect: try common names
+for (candidate in c("placebo", "Placebo", "PLACEBO", "control", "Control",
+                     "sham", "Sham", "standard care", "SOC")) {
+  if (candidate %in% all_treatments) {
+    inactive_treatment <- candidate
+    break
+  }
+}
+
+if (is.null(inactive_treatment)) {
+  # Fall back to single treatment with most studies
+  cat("No placebo/control found. Using most common single treatment as reference.\n")
+  single_counts <- nma_data %>%
+    tidyr::pivot_longer(cols = c(treat1, treat2), values_to = "trt") %>%
+    filter(trt %in% single_treatments) %>%
+    count(trt, sort = TRUE)
+  inactive_treatment <- single_counts$trt[1]
+}
+
+cat("Inactive (reference) treatment:", inactive_treatment, "\n\n")
+
+# =============================================================================
+# SECTION B: FREQUENTIST CNMA — ADDITIVE MODEL (PRIMARY)
+# =============================================================================
+
+cat("=== Frequentist CNMA: Additive Model (Primary Analysis) ===\n")
+
+# discomb() requires component columns in the data
+# It automatically creates the component design matrix
+cnma_add <- discomb(
+  TE, seTE, treat1, treat2, studlab,
+  data      = nma_data,
+  sm        = "RR",          # Adapt: "RR", "OR", "MD", "SMD"
+  random    = TRUE,
+  fixed     = TRUE,
+  inactive  = inactive_treatment
+)
+
+cat("Additive CNMA summary:\n")
+summary(cnma_add)
+
+# Component-level effects
+cat("\n--- Component Effects (Additive Model) ---\n")
+cat("These represent the marginal effect of adding each component\n")
+cat("relative to the inactive treatment.\n\n")
+
+# Forest plot of component effects
+png(file.path(FIG_DIR, "cnma_components_additive.png"),
+    width = FIG_WIDTH, height = max(6, length(all_components) * 1.2),
+    units = "in", res = FIG_DPI)
+
+forest(cnma_add,
+       leftcols  = c("studlab", "treat1", "treat2"),
+       leftlabs  = c("Study", "Treatment 1", "Treatment 2"))
+
+dev.off()
+cat("Component forest plot saved to",
+    file.path(FIG_DIR, "cnma_components_additive.png"), "\n")
+
+# Q-test: compare standard NMA vs additive CNMA
+cat("\n--- Model Comparison: Standard NMA vs Additive CNMA ---\n")
+cat("Q_diff (additive model Q - standard NMA Q) tests the additivity assumption.\n")
+cat("If p > 0.05: additive model is adequate.\n")
+cat("If p < 0.05: additivity assumption may not hold; consider interaction model.\n\n")
+
+cat("Additive CNMA heterogeneity:\n")
+cat("  Q =", cnma_add$Q, "(df =", cnma_add$df.Q, ", p =",
+    format.pval(cnma_add$pval.Q, digits = 4), ")\n")
+cat("  tau² =", round(cnma_add$tau2, 4), "\n")
+cat("  I² =", round(cnma_add$I2 * 100, 1), "%\n\n")
+
+# Compare with standard NMA tau²
+cat("Standard NMA tau²:", round(net_re$tau2, 4), "\n")
+cat("Additive CNMA tau²:", round(cnma_add$tau2, 4), "\n")
+if (cnma_add$tau2 < net_re$tau2) {
+  cat("→ Additive CNMA reduces heterogeneity (component model explains some variation).\n")
+} else {
+  cat("→ Additive CNMA does not reduce heterogeneity.\n")
+}
+
+# =============================================================================
+# SECTION C: FREQUENTIST CNMA — INTERACTION MODEL
+# =============================================================================
+
+cat("\n=== Frequentist CNMA: Interaction Model ===\n")
+
+# Fit interaction model (if sufficient data)
+# The interaction model allows synergy/antagonism between components
+cnma_int <- tryCatch({
+  discomb(
+    TE, seTE, treat1, treat2, studlab,
+    data      = nma_data,
+    sm        = "RR",
+    random    = TRUE,
+    fixed     = TRUE,
+    inactive  = inactive_treatment,
+    C.matrix  = "full"  # Full model includes interaction terms
+  )
+}, error = function(e) {
+  cat("Interaction model could not be fitted.\n")
+  cat("Reason:", conditionMessage(e), "\n")
+  cat("This may occur if there are insufficient studies to estimate interactions.\n")
+  NULL
+})
+
+if (!is.null(cnma_int)) {
+  cat("Interaction CNMA summary:\n")
+  summary(cnma_int)
+
+  # --- Interaction test ---
+  cat("\n--- Interaction Test ---\n")
+  cat("Tests whether component effects are purely additive or have interactions.\n")
+
+  # Compare additive vs interaction via Q-difference
+  q_diff   <- cnma_add$Q - cnma_int$Q
+  df_diff  <- cnma_add$df.Q - cnma_int$df.Q
+  p_interaction <- pchisq(q_diff, df = df_diff, lower.tail = FALSE)
+
+  cat("Q_additive:", round(cnma_add$Q, 2), "(df =", cnma_add$df.Q, ")\n")
+  cat("Q_interaction:", round(cnma_int$Q, 2), "(df =", cnma_int$df.Q, ")\n")
+  cat("Q_difference:", round(q_diff, 2), "(df =", df_diff, ")\n")
+  cat("p-value for interaction:", format.pval(p_interaction, digits = 4), "\n\n")
+
+  if (p_interaction < 0.05) {
+    cat("SIGNIFICANT INTERACTION detected (p < 0.05).\n")
+    cat("The combination effect differs from the sum of individual components.\n")
+    cat("Report the interaction model results and discuss clinical meaning.\n")
+  } else {
+    cat("No significant interaction (p >= 0.05).\n")
+    cat("The additive model is adequate — component effects are approximately additive.\n")
+    cat("Report the additive model as primary.\n")
+  }
+
+  # Save interaction test results
+  interaction_results <- data.frame(
+    Model      = c("Additive", "Interaction", "Difference"),
+    Q          = c(round(cnma_add$Q, 2), round(cnma_int$Q, 2), round(q_diff, 2)),
+    df         = c(cnma_add$df.Q, cnma_int$df.Q, df_diff),
+    p_value    = c(format.pval(cnma_add$pval.Q, digits = 4),
+                   format.pval(cnma_int$pval.Q, digits = 4),
+                   format.pval(p_interaction, digits = 4)),
+    tau2       = c(round(cnma_add$tau2, 4), round(cnma_int$tau2, 4), NA),
+    stringsAsFactors = FALSE
+  )
+
+  write_csv(interaction_results, file.path(TBL_DIR, "cnma_interaction_test.csv"))
+  cat("Interaction test results saved to",
+      file.path(TBL_DIR, "cnma_interaction_test.csv"), "\n")
+} else {
+  cat("Interaction model not available. Reporting additive model only.\n")
+}
+
+# =============================================================================
+# SECTION D: BAYESIAN CNMA (multinma — SENSITIVITY)
+# =============================================================================
+
+cat("\n=== Bayesian CNMA (multinma — Sensitivity Analysis) ===\n")
+
+if (exists("multinma_ok") && multinma_ok) {
+
+  # --- 1. Prepare data for multinma ---
+  # multinma uses its own data format; adapt from nma_data
+  # For contrast-based data:
+  cat("Preparing data for Bayesian CNMA (multinma)...\n")
+
+  bayes_cnma <- tryCatch({
+
+    # Create multinma network with component information
+    # Arm-based data preferred for multinma; adapt as needed:
+    #
+    # For arm-based data (events + totals):
+    # mnma_data <- set_agd_arm(arm_data,
+    #   study = study_id,
+    #   trt = treatment,
+    #   r = events,
+    #   n = total_n,
+    #   trt_ref = inactive_treatment
+    # )
+    #
+    # For contrast-based data (relative effects):
+    # mnma_data <- set_agd_contrast(contrast_data,
+    #   study = studlab,
+    #   trt = treat,
+    #   y = TE,
+    #   se = seTE,
+    #   trt_ref = inactive_treatment
+    # )
+
+    # Fit Bayesian additive CNMA
+    # The component model in multinma uses regression on component indicators
+    # Adapt the formula to your component structure:
+    #
+    # bayes_fit <- nma(mnma_data,
+    #   trt_effects = "random",
+    #   regression = ~ component1 + component2 + ...,
+    #   prior_intercept = normal(scale = 10),
+    #   prior_trt = normal(scale = 10),
+    #   prior_het = half_normal(scale = 1),
+    #   iter = 4000,
+    #   warmup = 2000,
+    #   chains = 4
+    # )
+
+    cat("NOTE: Bayesian CNMA requires manual adaptation of the multinma data\n")
+    cat("format and component regression formula for your specific dataset.\n")
+    cat("See nma_11_cnma.R comments for template code.\n")
+    cat("Uncomment and adapt the sections above.\n")
+    NULL
+  }, error = function(e) {
+    cat("Bayesian CNMA failed:", conditionMessage(e), "\n")
+    NULL
+  })
+
+  if (!is.null(bayes_cnma)) {
+    # Convergence diagnostics
+    cat("\n--- Bayesian CNMA Convergence Diagnostics ---\n")
+    # print(summary(bayes_cnma))
+
+    # Compare Bayesian vs frequentist
+    cat("\n--- Bayesian vs Frequentist CNMA Concordance ---\n")
+    cat("If results are concordant, report in manuscript:\n")
+    cat("'Bayesian CNMA (multinma/Stan) yielded consistent results\n")
+    cat(" with the frequentist CNMA (Supplement Table SX).'\n")
+  }
+
+} else {
+  cat("multinma not installed. Skipping Bayesian CNMA.\n")
+  cat("To enable: install.packages('multinma') (requires rstan or cmdstanr)\n")
+  cat("Frequentist CNMA (discomb) results remain the primary analysis.\n")
+}
+
+# =============================================================================
+# SECTION E: DISCONNECTED NETWORK RECONNECTION
+# =============================================================================
+
+cat("\n=== Disconnected Network Reconnection ===\n")
+
+# Check if the standard NMA network was disconnected
+nc <- netconnection(treat1, treat2, studlab, data = nma_data)
+
+if (nc$n.subnets > 1) {
+  cat("DISCONNECTED NETWORK detected (", nc$n.subnets, " sub-networks).\n")
+  cat("CNMA additive model may reconnect the network by assuming\n")
+  cat("that combination effects equal the sum of component effects.\n\n")
+
+  cat("WARNING: This is a STRONG assumption. The reconnected network\n")
+  cat("results should be reported as SENSITIVITY ANALYSIS only.\n")
+  cat("The additivity assumption must be clinically justified.\n\n")
+
+  # discomb() automatically handles disconnected networks
+  # The additive model creates implicit links through shared components
+  cat("The additive CNMA model above already includes the reconnected network.\n")
+  cat("Compare these results with the standard NMA (which excluded disconnected treatments).\n")
+
+} else {
+  cat("Network is fully connected. No reconnection needed.\n")
+  cat("CNMA results complement the standard NMA.\n")
+}
+
+# =============================================================================
+# SECTION F: CNMA-SPECIFIC OUTPUTS
+# =============================================================================
+
+cat("\n=== CNMA Output Summary ===\n")
+
+# --- Model comparison table ---
+model_comparison <- data.frame(
+  Model     = c("Standard NMA (netmeta)", "Additive CNMA", "Interaction CNMA"),
+  tau2      = c(round(net_re$tau2, 4),
+                round(cnma_add$tau2, 4),
+                ifelse(!is.null(cnma_int), round(cnma_int$tau2, 4), NA)),
+  I2_pct    = c(round(net_re$I2 * 100, 1),
+                round(cnma_add$I2 * 100, 1),
+                ifelse(!is.null(cnma_int), round(cnma_int$I2 * 100, 1), NA)),
+  Q         = c(round(net_re$Q, 2),
+                round(cnma_add$Q, 2),
+                ifelse(!is.null(cnma_int), round(cnma_int$Q, 2), NA)),
+  df        = c(net_re$df.Q,
+                cnma_add$df.Q,
+                ifelse(!is.null(cnma_int), cnma_int$df.Q, NA)),
+  stringsAsFactors = FALSE
+)
+
+write_csv(model_comparison, file.path(TBL_DIR, "cnma_model_comparison.csv"))
+cat("Model comparison table saved to",
+    file.path(TBL_DIR, "cnma_model_comparison.csv"), "\n")
+print(model_comparison)
+
+# --- Save comprehensive report ---
+sink("cnma_report.txt")
+cat("========================================\n")
+cat("COMPONENT NETWORK META-ANALYSIS REPORT\n")
+cat("========================================\n\n")
+
+cat("Reference treatment (inactive):", inactive_treatment, "\n")
+cat("Combination treatments:", paste(combo_treatments, collapse = ", "), "\n")
+cat("Components identified:", paste(all_components, collapse = ", "), "\n\n")
+
+cat("--- Component Matrix ---\n")
+print(component_matrix)
+
+cat("\n--- Additive CNMA (Primary) ---\n")
+summary(cnma_add)
+
+if (!is.null(cnma_int)) {
+  cat("\n--- Interaction CNMA ---\n")
+  summary(cnma_int)
+  cat("\n--- Interaction Test ---\n")
+  cat("Q_difference:", round(q_diff, 2), "(df =", df_diff,
+      ", p =", format.pval(p_interaction, digits = 4), ")\n")
+}
+
+cat("\n--- Model Comparison ---\n")
+print(model_comparison)
+
+cat("\n--- Network Connectivity ---\n")
+cat("Sub-networks:", nc$n.subnets, "\n")
+if (nc$n.subnets > 1) {
+  cat("CNMA reconnected the network via additive assumption (sensitivity only).\n")
+}
+sink()
+
+cat("\nCNMA report saved to cnma_report.txt\n")
+cat("CNMA analysis complete.\n")

--- a/ma-network-meta-analysis/assets/r/nma_12_meta_regression.R
+++ b/ma-network-meta-analysis/assets/r/nma_12_meta_regression.R
@@ -1,0 +1,317 @@
+# =============================================================================
+# nma_12_meta_regression.R — NMA Meta-Regression & Subgroup Analysis
+# =============================================================================
+# Purpose: Explore heterogeneity sources via NMA meta-regression (continuous
+#          and categorical covariates) and subgroup NMA analyses
+# Input: net_re, nma_data from nma_04_models.R
+# Output: Regression coefficients, bubble plots, subgroup comparisons
+# Reference: Donegan et al. (2013) — Assessing key assumptions of NMA
+# =============================================================================
+
+source("nma_04_models.R")
+
+# =============================================================================
+# SECTION A: NMA META-REGRESSION (CONTINUOUS COVARIATES)
+# =============================================================================
+
+cat("=== NMA Meta-Regression ===\n")
+cat("Tests whether study-level covariates explain heterogeneity in the network.\n\n")
+
+# --- 1. Define covariates ---
+# Adapt to your extraction data columns.
+# These should be study-level (same value for all arms within a study).
+# Common covariates: mean_age, year, sample_size, follow_up_months, risk_of_bias_score
+
+continuous_covariates <- c()  # e.g., c("mean_age", "year", "follow_up_months")
+categorical_covariates <- c() # e.g., c("risk_of_bias", "region", "blinding")
+
+# Check which covariates are available in nma_data
+available_cols <- names(nma_data)
+cat("Available columns in nma_data:", paste(available_cols, collapse = ", "), "\n\n")
+
+# --- 2. Fit meta-regression for each continuous covariate ---
+if (length(continuous_covariates) > 0) {
+  cat("--- Continuous Covariate Meta-Regression ---\n")
+
+  metareg_results <- list()
+
+  for (covar in continuous_covariates) {
+    if (!covar %in% available_cols) {
+      cat("Skipping", covar, "- not found in data\n")
+      next
+    }
+
+    # Check for sufficient non-missing values
+    n_available <- sum(!is.na(nma_data[[covar]]))
+    if (n_available < 5) {
+      cat("Skipping", covar, "- only", n_available, "non-missing values\n")
+      next
+    }
+
+    cat("\nMeta-regression:", covar, "\n")
+
+    reg <- tryCatch({
+      netmetareg(net_re, formula = as.formula(paste("~", covar)))
+    }, error = function(e) {
+      cat("  Failed:", conditionMessage(e), "\n")
+      NULL
+    })
+
+    if (!is.null(reg)) {
+      cat("  Coefficient:", round(coef(reg)[covar], 4), "\n")
+      cat("  p-value:", format.pval(reg$pval.random[covar], digits = 4), "\n")
+      cat("  Residual tau²:", round(reg$tau2, 4),
+          "(baseline:", round(net_re$tau2, 4), ")\n")
+
+      tau2_reduction <- (1 - reg$tau2 / net_re$tau2) * 100
+      cat("  tau² reduction:", round(tau2_reduction, 1), "%\n")
+
+      metareg_results[[covar]] <- list(
+        covariate     = covar,
+        coefficient   = coef(reg)[covar],
+        se            = reg$se[covar],
+        pvalue        = reg$pval.random[covar],
+        tau2_residual = reg$tau2,
+        tau2_baseline = net_re$tau2,
+        tau2_reduction_pct = tau2_reduction
+      )
+
+      # Bubble plot
+      png(file.path(FIG_DIR, paste0("nma_metareg_", covar, ".png")),
+          width = FIG_WIDTH, height = FIG_HEIGHT, units = "in", res = FIG_DPI)
+
+      bubble(reg,
+             xlab     = covar,
+             ylab     = paste("Treatment effect (", net_re$sm, ")"),
+             main     = paste("NMA Meta-Regression:", covar),
+             col      = "steelblue",
+             studlab  = TRUE,
+             cex.studlab = 0.7)
+
+      dev.off()
+      cat("  Bubble plot saved to",
+          file.path(FIG_DIR, paste0("nma_metareg_", covar, ".png")), "\n")
+    }
+  }
+
+  # Summary table
+  if (length(metareg_results) > 0) {
+    metareg_df <- do.call(rbind, lapply(metareg_results, function(x) {
+      data.frame(
+        Covariate    = x$covariate,
+        Coefficient  = round(x$coefficient, 4),
+        SE           = round(x$se, 4),
+        p_value      = format.pval(x$pvalue, digits = 4),
+        tau2_residual = round(x$tau2_residual, 4),
+        tau2_reduction_pct = round(x$tau2_reduction_pct, 1),
+        stringsAsFactors = FALSE
+      )
+    }))
+
+    write_csv(metareg_df, file.path(TBL_DIR, "nma_metareg_results.csv"))
+    cat("\nMeta-regression summary saved to",
+        file.path(TBL_DIR, "nma_metareg_results.csv"), "\n")
+    print(metareg_df)
+  }
+} else {
+  cat("No continuous covariates specified.\n")
+  cat("Adapt continuous_covariates vector at the top of this script.\n\n")
+}
+
+# =============================================================================
+# SECTION B: NMA META-REGRESSION (CATEGORICAL COVARIATES)
+# =============================================================================
+
+if (length(categorical_covariates) > 0) {
+  cat("\n--- Categorical Covariate Meta-Regression ---\n")
+
+  cat_metareg_results <- list()
+
+  for (covar in categorical_covariates) {
+    if (!covar %in% available_cols) {
+      cat("Skipping", covar, "- not found in data\n")
+      next
+    }
+
+    # Check for sufficient categories
+    categories <- unique(nma_data[[covar]][!is.na(nma_data[[covar]])])
+    if (length(categories) < 2) {
+      cat("Skipping", covar, "- only", length(categories), "category\n")
+      next
+    }
+
+    cat("\nMeta-regression:", covar, "(categories:", paste(categories, collapse = ", "), ")\n")
+
+    reg <- tryCatch({
+      netmetareg(net_re, formula = as.formula(paste("~ factor(", covar, ")")))
+    }, error = function(e) {
+      cat("  Failed:", conditionMessage(e), "\n")
+      NULL
+    })
+
+    if (!is.null(reg)) {
+      cat("  Coefficients:\n")
+      print(round(coef(reg), 4))
+      cat("  Residual tau²:", round(reg$tau2, 4), "\n")
+
+      cat_metareg_results[[covar]] <- reg
+    }
+  }
+} else {
+  cat("No categorical covariates specified.\n")
+  cat("Adapt categorical_covariates vector at the top of this script.\n\n")
+}
+
+# =============================================================================
+# SECTION C: SUBGROUP NMA
+# =============================================================================
+
+cat("\n=== Subgroup NMA ===\n")
+cat("Fits separate NMA models within subgroups to compare treatment effects.\n\n")
+
+# Define subgroup variable (must be study-level, categorical)
+# Adapt to your data:
+subgroup_var <- NULL  # e.g., "risk_of_bias_level", "geographic_region"
+
+if (!is.null(subgroup_var) && subgroup_var %in% available_cols) {
+
+  subgroups <- unique(nma_data[[subgroup_var]][!is.na(nma_data[[subgroup_var]])])
+  cat("Subgroup variable:", subgroup_var, "\n")
+  cat("Subgroups:", paste(subgroups, collapse = ", "), "\n\n")
+
+  subgroup_results <- list()
+
+  for (sg in subgroups) {
+    cat("--- Subgroup:", sg, "---\n")
+
+    sg_data <- nma_data[nma_data[[subgroup_var]] == sg, ]
+    cat("Studies in subgroup:", length(unique(sg_data$studlab)), "\n")
+
+    # Check connectivity within subgroup
+    nc_sg <- tryCatch(
+      netconnection(sg_data$treat1, sg_data$treat2, sg_data$studlab),
+      error = function(e) NULL
+    )
+
+    if (is.null(nc_sg) || nc_sg$n.subnets > 1) {
+      cat("Subgroup network is disconnected. Skipping NMA for this subgroup.\n\n")
+      next
+    }
+
+    # Fit subgroup NMA
+    net_sg <- tryCatch(
+      netmeta(TE, seTE, treat1, treat2, studlab,
+              data = sg_data, sm = "RR",
+              random = TRUE, method.tau = "REML"),
+      error = function(e) {
+        cat("NMA failed for subgroup:", conditionMessage(e), "\n")
+        NULL
+      }
+    )
+
+    if (!is.null(net_sg)) {
+      cat("tau²:", round(net_sg$tau2, 4), "\n")
+      cat("I²:", round(net_sg$I2 * 100, 1), "%\n\n")
+
+      subgroup_results[[sg]] <- list(
+        subgroup   = sg,
+        n_studies  = length(unique(sg_data$studlab)),
+        tau2       = net_sg$tau2,
+        I2         = net_sg$I2,
+        net        = net_sg
+      )
+
+      # Subgroup forest plot
+      png(file.path(FIG_DIR, paste0("nma_subgroup_", sg, ".png")),
+          width = FIG_WIDTH, height = FIG_HEIGHT, units = "in", res = FIG_DPI)
+
+      forest(net_sg,
+             reference.group = net_re$reference.group,
+             sortvar = TE,
+             label.left  = paste("Favours", net_re$reference.group),
+             label.right = "Favours treatment")
+
+      dev.off()
+      cat("Forest plot saved to",
+          file.path(FIG_DIR, paste0("nma_subgroup_", sg, ".png")), "\n\n")
+    }
+  }
+
+  # --- Subgroup comparison table ---
+  if (length(subgroup_results) > 1) {
+    cat("--- Subgroup Comparison ---\n")
+
+    subgroup_df <- do.call(rbind, lapply(subgroup_results, function(x) {
+      data.frame(
+        Subgroup    = x$subgroup,
+        N_studies   = x$n_studies,
+        tau2        = round(x$tau2, 4),
+        I2_pct      = round(x$I2 * 100, 1),
+        stringsAsFactors = FALSE
+      )
+    }))
+
+    write_csv(subgroup_df, file.path(TBL_DIR, "nma_subgroup_comparison.csv"))
+    cat("Subgroup comparison saved to",
+        file.path(TBL_DIR, "nma_subgroup_comparison.csv"), "\n")
+    print(subgroup_df)
+  }
+
+} else {
+  cat("No subgroup variable specified (or not found in data).\n")
+  cat("Set subgroup_var at the top of Section C to enable subgroup NMA.\n")
+  cat("Example: subgroup_var <- 'risk_of_bias_level'\n\n")
+}
+
+# =============================================================================
+# SECTION D: OUTPUTS
+# =============================================================================
+
+cat("\n=== Meta-Regression & Subgroup Summary ===\n")
+
+# Heterogeneity explained summary
+het_summary <- data.frame(
+  Model     = "Full NMA (no covariates)",
+  tau2      = round(net_re$tau2, 4),
+  I2_pct    = round(net_re$I2 * 100, 1),
+  stringsAsFactors = FALSE
+)
+
+if (exists("metareg_results") && length(metareg_results) > 0) {
+  for (covar_name in names(metareg_results)) {
+    res <- metareg_results[[covar_name]]
+    het_summary <- rbind(het_summary, data.frame(
+      Model  = paste("Adjusted for", covar_name),
+      tau2   = round(res$tau2_residual, 4),
+      I2_pct = NA,
+      stringsAsFactors = FALSE
+    ))
+  }
+}
+
+write_csv(het_summary, file.path(TBL_DIR, "nma_heterogeneity_explained.csv"))
+cat("Heterogeneity summary saved to",
+    file.path(TBL_DIR, "nma_heterogeneity_explained.csv"), "\n")
+print(het_summary)
+
+# --- Save report ---
+sink("nma_metareg_report.txt")
+cat("==========================================\n")
+cat("NMA META-REGRESSION & SUBGROUP REPORT\n")
+cat("==========================================\n\n")
+
+cat("--- Heterogeneity Explained ---\n")
+print(het_summary)
+
+if (exists("metareg_df") && nrow(metareg_df) > 0) {
+  cat("\n--- Meta-Regression Coefficients ---\n")
+  print(metareg_df)
+}
+
+if (exists("subgroup_df") && nrow(subgroup_df) > 0) {
+  cat("\n--- Subgroup Comparison ---\n")
+  print(subgroup_df)
+}
+sink()
+
+cat("\nMeta-regression report saved to nma_metareg_report.txt\n")

--- a/ma-network-meta-analysis/assets/r/nma_13_transitivity_tests.R
+++ b/ma-network-meta-analysis/assets/r/nma_13_transitivity_tests.R
@@ -1,0 +1,409 @@
+# =============================================================================
+# nma_13_transitivity_tests.R — Statistical Transitivity Assessment
+# =============================================================================
+# Purpose: Supplement clinical transitivity assessment (nma-assumptions.md)
+#          with quantitative statistical tests for effect modifier balance
+# Input: net_re, nma_data from nma_04_models.R; study-level covariates
+# Output: Transitivity test results, heatmap, traffic light table
+# Note: These tests are NOT definitive — transitivity remains a clinical
+#       judgment. Statistical tests provide supporting evidence only.
+# Reference: Salanti (2012); Donegan et al. (2013)
+# =============================================================================
+
+source("nma_04_models.R")
+
+# =============================================================================
+# SECTION A: EFFECT MODIFIER DISTRIBUTION COMPARISON
+# =============================================================================
+
+cat("=== Statistical Transitivity Assessment ===\n")
+cat("Tests whether potential effect modifiers are balanced across comparisons.\n")
+cat("NOTE: These tests supplement — not replace — clinical judgment.\n\n")
+
+# --- 1. Define potential effect modifiers ---
+# Adapt to your extraction data columns.
+# These should be study-level characteristics that could modify treatment effects.
+
+continuous_modifiers  <- c()  # e.g., c("mean_age", "percent_female", "follow_up_months")
+categorical_modifiers <- c()  # e.g., c("disease_stage", "line_of_therapy", "risk_of_bias")
+
+available_cols <- names(nma_data)
+cat("Available columns:", paste(available_cols, collapse = ", "), "\n\n")
+
+# --- 2. Create comparison identifier ---
+# Group studies by their pairwise comparison
+nma_data$comparison <- paste(
+  pmin(nma_data$treat1, nma_data$treat2),
+  pmax(nma_data$treat1, nma_data$treat2),
+  sep = " vs "
+)
+
+comparisons <- sort(unique(nma_data$comparison))
+cat("Unique comparisons:", length(comparisons), "\n")
+cat(paste(" -", comparisons), sep = "\n")
+cat("\n")
+
+# --- 3. Test continuous modifiers ---
+continuous_results <- list()
+
+if (length(continuous_modifiers) > 0) {
+  cat("--- Continuous Effect Modifier Tests ---\n")
+  cat("Using Kruskal-Wallis test (non-parametric ANOVA across comparisons)\n\n")
+
+  for (modifier in continuous_modifiers) {
+    if (!modifier %in% available_cols) {
+      cat("Skipping", modifier, "- not found in data\n")
+      next
+    }
+
+    # Remove missing values
+    test_data <- nma_data[!is.na(nma_data[[modifier]]), ]
+
+    # Need at least 2 comparisons with data
+    comp_counts <- table(test_data$comparison)
+    valid_comps <- names(comp_counts[comp_counts >= 1])
+
+    if (length(valid_comps) < 2) {
+      cat("Skipping", modifier, "- data in fewer than 2 comparisons\n")
+      next
+    }
+
+    test_data <- test_data[test_data$comparison %in% valid_comps, ]
+
+    # Kruskal-Wallis test
+    kw <- tryCatch(
+      kruskal.test(as.formula(paste(modifier, "~ comparison")), data = test_data),
+      error = function(e) NULL
+    )
+
+    if (!is.null(kw)) {
+      cat(modifier, ": H =", round(kw$statistic, 2),
+          ", df =", kw$parameter,
+          ", p =", format.pval(kw$p.value, digits = 4), "\n")
+
+      # Concern level
+      concern <- ifelse(kw$p.value < 0.01, "High",
+                   ifelse(kw$p.value < 0.10, "Moderate", "Low"))
+      cat("  → Concern:", concern, "\n")
+
+      # Summary by comparison
+      comp_summary <- test_data %>%
+        group_by(comparison) %>%
+        summarise(
+          n      = n(),
+          median = round(median(.data[[modifier]], na.rm = TRUE), 1),
+          IQR    = paste0(round(quantile(.data[[modifier]], 0.25, na.rm = TRUE), 1),
+                          "-",
+                          round(quantile(.data[[modifier]], 0.75, na.rm = TRUE), 1)),
+          .groups = "drop"
+        )
+      print(as.data.frame(comp_summary))
+      cat("\n")
+
+      continuous_results[[modifier]] <- list(
+        modifier  = modifier,
+        statistic = kw$statistic,
+        df        = kw$parameter,
+        p_value   = kw$p.value,
+        concern   = concern
+      )
+    }
+  }
+}
+
+# --- 4. Test categorical modifiers ---
+categorical_results <- list()
+
+if (length(categorical_modifiers) > 0) {
+  cat("--- Categorical Effect Modifier Tests ---\n")
+  cat("Using Chi-squared / Fisher's exact test across comparisons\n\n")
+
+  for (modifier in categorical_modifiers) {
+    if (!modifier %in% available_cols) {
+      cat("Skipping", modifier, "- not found in data\n")
+      next
+    }
+
+    test_data <- nma_data[!is.na(nma_data[[modifier]]), ]
+
+    # Contingency table: comparison × modifier category
+    ct <- table(test_data$comparison, test_data[[modifier]])
+
+    if (nrow(ct) < 2 || ncol(ct) < 2) {
+      cat("Skipping", modifier, "- insufficient variation\n")
+      next
+    }
+
+    # Use Fisher's exact test if any expected cell < 5
+    expected <- chisq.test(ct)$expected
+    use_fisher <- any(expected < 5)
+
+    test_result <- tryCatch({
+      if (use_fisher) {
+        fisher.test(ct, simulate.p.value = TRUE, B = 10000)
+      } else {
+        chisq.test(ct)
+      }
+    }, error = function(e) NULL)
+
+    if (!is.null(test_result)) {
+      test_name <- ifelse(use_fisher, "Fisher's exact", "Chi-squared")
+      cat(modifier, "(", test_name, "): p =",
+          format.pval(test_result$p.value, digits = 4), "\n")
+
+      concern <- ifelse(test_result$p.value < 0.01, "High",
+                   ifelse(test_result$p.value < 0.10, "Moderate", "Low"))
+      cat("  → Concern:", concern, "\n")
+
+      cat("  Contingency table:\n")
+      print(ct)
+      cat("\n")
+
+      categorical_results[[modifier]] <- list(
+        modifier  = modifier,
+        test      = test_name,
+        p_value   = test_result$p.value,
+        concern   = concern
+      )
+    }
+  }
+}
+
+# =============================================================================
+# SECTION B: NETWORK META-REGRESSION AS TRANSITIVITY PROXY
+# =============================================================================
+
+cat("\n=== Meta-Regression Transitivity Proxy ===\n")
+cat("If adding a covariate substantially changes NMA results,\n")
+cat("that covariate may violate transitivity.\n\n")
+
+all_modifiers <- c(continuous_modifiers, categorical_modifiers)
+regression_proxy_results <- list()
+
+for (modifier in all_modifiers) {
+  if (!modifier %in% available_cols) next
+  if (sum(!is.na(nma_data[[modifier]])) < 5) next
+
+  cat("Testing:", modifier, "\n")
+
+  # Fit NMA with and without the covariate
+  reg_adjusted <- tryCatch({
+    if (modifier %in% continuous_modifiers) {
+      netmetareg(net_re, formula = as.formula(paste("~", modifier)))
+    } else {
+      netmetareg(net_re, formula = as.formula(paste("~ factor(", modifier, ")")))
+    }
+  }, error = function(e) NULL)
+
+  if (!is.null(reg_adjusted)) {
+    tau2_change <- (reg_adjusted$tau2 - net_re$tau2) / net_re$tau2 * 100
+
+    cat("  tau² unadjusted:", round(net_re$tau2, 4), "\n")
+    cat("  tau² adjusted:", round(reg_adjusted$tau2, 4), "\n")
+    cat("  Change:", round(tau2_change, 1), "%\n")
+
+    # Large tau² reduction suggests the covariate explains heterogeneity
+    # which may indicate it's an effect modifier violating transitivity
+    if (abs(tau2_change) > 20) {
+      cat("  → NOTABLE: >20% change in tau² — potential transitivity concern\n")
+    }
+    cat("\n")
+
+    regression_proxy_results[[modifier]] <- list(
+      modifier      = modifier,
+      tau2_before   = net_re$tau2,
+      tau2_after    = reg_adjusted$tau2,
+      tau2_change_pct = tau2_change
+    )
+  }
+}
+
+# =============================================================================
+# SECTION C: DIRECT vs FULL NMA COMPARISON (Salanti 2012 approach)
+# =============================================================================
+
+cat("\n=== Direct vs Full NMA Comparison ===\n")
+cat("Compares direct-only estimates with full NMA estimates.\n")
+cat("Systematic discrepancies may suggest transitivity violations.\n")
+cat("(This complements node-splitting in nma_05_inconsistency.R)\n\n")
+
+# Get node-splitting results (direct vs indirect vs NMA)
+ns <- netsplit(net_re)
+ns_df <- as.data.frame(ns)
+
+if (nrow(ns_df) > 0 && "direct" %in% names(ns_df) && "nma" %in% names(ns_df)) {
+  cat("Comparisons with both direct and indirect evidence:\n\n")
+
+  # Calculate absolute differences between direct and NMA estimates
+  if ("TE.direct" %in% names(ns_df) && "TE.nma" %in% names(ns_df)) {
+    ns_df$diff_direct_nma <- abs(ns_df$TE.direct - ns_df$TE.nma)
+
+    cat("Direct vs NMA estimate differences:\n")
+    for (i in seq_len(nrow(ns_df))) {
+      cat(sprintf("  %s: |direct - NMA| = %.3f",
+                  ns_df$comparison[i],
+                  ns_df$diff_direct_nma[i]))
+      if (!is.na(ns_df$p.value[i]) && ns_df$p.value[i] < 0.10) {
+        cat(" ** (p < 0.10)")
+      }
+      cat("\n")
+    }
+
+    # Overall assessment
+    n_sig <- sum(ns_df$p.value < 0.10, na.rm = TRUE)
+    n_total <- sum(!is.na(ns_df$p.value))
+
+    cat("\nComparisons with p < 0.10 (local inconsistency):",
+        n_sig, "/", n_total, "\n")
+
+    if (n_sig == 0) {
+      cat("→ No significant direct-indirect discrepancies.\n")
+      cat("  Transitivity assumption appears supported by evidence.\n")
+    } else if (n_sig / n_total < 0.20) {
+      cat("→ Few discrepancies detected. Investigate specific comparisons.\n")
+    } else {
+      cat("→ Multiple discrepancies. Transitivity may be violated.\n")
+      cat("  Consider meta-regression to identify the effect modifier.\n")
+    }
+  }
+} else {
+  cat("Node-splitting results not available or insufficient for comparison.\n")
+}
+
+# =============================================================================
+# SECTION D: TRANSITIVITY ASSESSMENT SUMMARY
+# =============================================================================
+
+cat("\n=== Transitivity Assessment Summary ===\n")
+
+# Compile all results into a traffic light table
+traffic_light <- data.frame(
+  Modifier   = character(),
+  Test       = character(),
+  p_value    = numeric(),
+  Concern    = character(),
+  stringsAsFactors = FALSE
+)
+
+for (res in continuous_results) {
+  traffic_light <- rbind(traffic_light, data.frame(
+    Modifier = res$modifier,
+    Test     = "Kruskal-Wallis",
+    p_value  = res$p_value,
+    Concern  = res$concern,
+    stringsAsFactors = FALSE
+  ))
+}
+
+for (res in categorical_results) {
+  traffic_light <- rbind(traffic_light, data.frame(
+    Modifier = res$modifier,
+    Test     = res$test,
+    p_value  = res$p_value,
+    Concern  = res$concern,
+    stringsAsFactors = FALSE
+  ))
+}
+
+if (nrow(traffic_light) > 0) {
+  cat("\n--- Traffic Light Table ---\n")
+  cat("Green (Low): p >= 0.10 — modifier balanced across comparisons\n")
+  cat("Yellow (Moderate): 0.01 <= p < 0.10 — some imbalance\n")
+  cat("Red (High): p < 0.01 — significant imbalance, transitivity concern\n\n")
+
+  traffic_light$p_value <- format.pval(traffic_light$p_value, digits = 4)
+  print(traffic_light)
+
+  write_csv(traffic_light, file.path(TBL_DIR, "transitivity_tests.csv"))
+  cat("\nTraffic light table saved to",
+      file.path(TBL_DIR, "transitivity_tests.csv"), "\n")
+
+  # Heatmap visualization (if ggplot2 available)
+  if (nrow(traffic_light) >= 2) {
+    traffic_light_plot <- traffic_light
+    traffic_light_plot$p_numeric <- as.numeric(traffic_light_plot$p_value)
+
+    png(file.path(FIG_DIR, "transitivity_heatmap.png"),
+        width = FIG_WIDTH, height = max(4, nrow(traffic_light_plot) * 0.8),
+        units = "in", res = FIG_DPI)
+
+    p <- ggplot(traffic_light_plot, aes(x = "Balance", y = Modifier)) +
+      geom_tile(aes(fill = Concern), color = "white", linewidth = 1) +
+      geom_text(aes(label = p_value), size = 4) +
+      scale_fill_manual(
+        values = c("Low" = "#4CAF50", "Moderate" = "#FFC107", "High" = "#F44336"),
+        name   = "Concern Level"
+      ) +
+      theme_minimal() +
+      labs(
+        title = "Transitivity Assessment: Effect Modifier Balance",
+        subtitle = "p-values for distribution across network comparisons",
+        x = NULL, y = NULL
+      ) +
+      theme(axis.text.x = element_blank(),
+            panel.grid = element_blank())
+
+    print(p)
+    dev.off()
+    cat("Heatmap saved to", file.path(FIG_DIR, "transitivity_heatmap.png"), "\n")
+  }
+
+  # Overall assessment
+  n_high <- sum(traffic_light$Concern == "High")
+  n_mod  <- sum(traffic_light$Concern == "Moderate")
+
+  cat("\n--- Overall Transitivity Assessment ---\n")
+  cat("High concern modifiers:", n_high, "\n")
+  cat("Moderate concern modifiers:", n_mod, "\n")
+
+  if (n_high == 0 && n_mod == 0) {
+    cat("→ All modifiers balanced. Statistical evidence supports transitivity.\n")
+  } else if (n_high == 0) {
+    cat("→ Some imbalance detected. Clinical assessment should confirm.\n")
+  } else {
+    cat("→ Significant imbalance detected. Transitivity may be violated.\n")
+    cat("  Consider sensitivity analysis excluding problematic comparisons.\n")
+    cat("  Downgrade GRADE certainty for affected comparisons.\n")
+  }
+
+} else {
+  cat("No effect modifiers specified for testing.\n")
+  cat("Adapt continuous_modifiers and categorical_modifiers at the top of this script.\n")
+  cat("Even without statistical tests, complete the clinical transitivity table\n")
+  cat("in nma-assumptions.md (study characteristics by comparison).\n")
+}
+
+# --- Save comprehensive report ---
+sink("transitivity_assessment_report.txt")
+cat("================================================\n")
+cat("TRANSITIVITY ASSESSMENT REPORT\n")
+cat("================================================\n\n")
+
+cat("NOTE: Statistical transitivity tests are SUPPLEMENTARY.\n")
+cat("Transitivity remains primarily a clinical judgment.\n")
+cat("See nma-assumptions.md for the clinical assessment table.\n\n")
+
+if (nrow(traffic_light) > 0) {
+  cat("--- Effect Modifier Balance (Traffic Light) ---\n")
+  print(traffic_light)
+}
+
+if (length(regression_proxy_results) > 0) {
+  cat("\n--- Meta-Regression Proxy ---\n")
+  for (res in regression_proxy_results) {
+    cat(res$modifier, ": tau² change =", round(res$tau2_change_pct, 1), "%\n")
+  }
+}
+
+cat("\n--- Direct vs NMA Comparison ---\n")
+if (exists("ns_df") && nrow(ns_df) > 0) {
+  cat("Comparisons with local inconsistency (p < 0.10):", n_sig, "/", n_total, "\n")
+}
+
+cat("\n--- Interpretation ---\n")
+cat("Combine these statistical results with the clinical transitivity\n")
+cat("assessment table (study characteristics by comparison) for a\n")
+cat("comprehensive evaluation of the transitivity assumption.\n")
+sink()
+
+cat("\nTransitivity assessment report saved to transitivity_assessment_report.txt\n")

--- a/ma-network-meta-analysis/references/cnma-guide.md
+++ b/ma-network-meta-analysis/references/cnma-guide.md
@@ -1,0 +1,222 @@
+# Component Network Meta-Analysis (CNMA): Guide
+
+**Time**: 15 minutes
+**Purpose**: Understand when and how to use Component NMA for combination therapies
+**Script**: `nma_11_cnma.R`
+
+---
+
+## What is CNMA?
+
+Standard NMA treats each treatment as a single entity. Component NMA (CNMA) **decomposes multi-component treatments** into their individual parts and estimates the contribution of each component.
+
+**Mathematical basis**: In the additive model, the effect of a combination treatment A+B is:
+
+```
+effect(A+B) = effect(A) + effect(B)
+```
+
+The interaction model relaxes this:
+
+```
+effect(A+B) = effect(A) + effect(B) + interaction(A,B)
+```
+
+---
+
+## When to Use CNMA
+
+Use CNMA when **any** of these apply:
+
+1. **Combination therapies** exist in the network (e.g., ACEI+ARB, Chemo+Immuno, Drug A + Drug B)
+2. **Disconnected network** that could be reconnected if treatments share components
+3. You want to **estimate individual component contributions** to the combination effect
+4. You want to **test for synergy or antagonism** between components
+
+### Examples
+
+| Clinical Scenario | Standard NMA | CNMA Advantage |
+|---|---|---|
+| ACEI vs ARB vs ACEI+ARB | Treats ACEI+ARB as opaque | Tests if ACEI+ARB > ACEI + ARB (interaction) |
+| Chemo vs Immuno vs Chemo+Immuno | 3-node network | Decomposes into chemo effect + immuno effect |
+| A vs B, C+B vs D (disconnected) | Cannot fit NMA | Additive model connects via shared component B |
+
+---
+
+## When NOT to Use CNMA
+
+- **All treatments are single-component** — standard NMA is sufficient
+- **Additivity is clearly implausible** — known strong synergy/antagonism between components (additivity assumption fails)
+- **Fewer than 3 studies involving combinations** — insufficient data to estimate component effects
+- **Components cannot be identified** — treatment mechanisms are not decomposable
+
+---
+
+## Data Requirements
+
+### Treatment Naming Convention
+
+Treatments must encode their components using `+` as separator:
+
+| Treatment Label | Components |
+|---|---|
+| `ACEI` | ACEI |
+| `ARB` | ARB |
+| `ACEI+ARB` | ACEI, ARB |
+| `Placebo` | (inactive reference) |
+| `Chemo+Immuno+RT` | Chemo, Immuno, RT |
+
+### Minimum Data
+
+- At least **some studies** must compare combination treatments
+- At least **some studies** must include single-component arms (for identifiability)
+- The **inactive treatment** (reference) must be defined (typically placebo or standard care)
+
+---
+
+## Additive vs Interaction Model
+
+### Decision Process
+
+```
+1. Fit additive model (no interaction)
+   ↓
+2. Fit interaction model (with interaction terms)
+   ↓
+3. Compare via Q-test (likelihood ratio)
+   ├─ p > 0.05 → Additive model adequate (primary)
+   └─ p < 0.05 → Interaction present (report interaction model)
+```
+
+### Additive Model
+
+- **Assumption**: Components contribute independently
+- **Advantage**: More parsimonious, fewer parameters, can reconnect disconnected networks
+- **Report**: Component-level effect estimates with CIs
+
+### Interaction Model
+
+- **No additivity assumption**: Allows synergy (positive interaction) or antagonism (negative interaction)
+- **Disadvantage**: More parameters, requires more data
+- **Report**: Component effects + interaction terms
+
+### Interpretation Guide
+
+| Interaction Test | Meaning | Action |
+|---|---|---|
+| p > 0.10 | No interaction | Report additive model |
+| 0.05 < p < 0.10 | Borderline | Report both; discuss |
+| p < 0.05 | Significant interaction | Report interaction model; discuss clinical meaning |
+
+---
+
+## Reconnecting Disconnected Networks
+
+CNMA's additive model can reconnect networks that would otherwise be disconnected in standard NMA:
+
+```
+Standard NMA (disconnected):
+  A --- B           C --- D
+  (no link between AB and CD sub-networks)
+
+CNMA (reconnected via shared component):
+  A --- B --- ? --- C --- D
+  If B appears as a component in treatments on both sides,
+  the additive model creates implicit connections.
+```
+
+### Caveats
+
+- **Strong assumption**: Additivity must be clinically plausible
+- **Always report** results WITH and WITHOUT disconnected treatments
+- **Flag as sensitivity analysis**, not primary analysis
+- **Discuss** why additivity is or isn't reasonable for your clinical context
+
+---
+
+## R Implementation
+
+### Frequentist (Primary): `netmeta::discomb()`
+
+```r
+# Additive model
+cnma_add <- discomb(TE, seTE, treat1, treat2, studlab,
+                    data = nma_data, sm = "RR",
+                    random = TRUE, inactive = "placebo")
+
+# Interaction model
+cnma_int <- discomb(TE, seTE, treat1, treat2, studlab,
+                    data = nma_data, sm = "RR",
+                    random = TRUE, inactive = "placebo",
+                    C.matrix = "full")
+
+# Forest plot of component effects
+forest(cnma_add)
+
+# Compare models
+q_diff <- cnma_add$Q - cnma_int$Q
+df_diff <- cnma_add$df.Q - cnma_int$df.Q
+p_interaction <- pchisq(q_diff, df = df_diff, lower.tail = FALSE)
+```
+
+### Bayesian (Sensitivity): `multinma`
+
+```r
+library(multinma)
+
+# Prepare data with component indicators
+# Fit Bayesian CNMA with component regression terms
+# See nma_11_cnma.R Section D for detailed template
+```
+
+### Why Frequentist Leads for CNMA
+
+Unlike standard NMA where Bayesian (gemtc) is primary:
+
+- `discomb()` is the **reference implementation** by Rücker et al. (2020)
+- It is purpose-built for CNMA, while multinma uses general regression
+- **No JAGS/Stan dependency** — easier to reproduce
+- Bayesian CNMA via multinma is placed in supplement for robustness
+
+---
+
+## Reporting Checklist (CNMA-Specific Additions)
+
+When reporting CNMA results, include these **in addition to** the standard NMA checklist:
+
+- [ ] Component definitions: how treatments were decomposed
+- [ ] Additive model results: component-level effect estimates with CIs
+- [ ] Interaction test: Q-test results and interpretation
+- [ ] Model comparison: standard NMA vs additive CNMA vs interaction CNMA (tau², I², Q)
+- [ ] If network reconnected: explicit discussion of additivity assumption and its plausibility
+- [ ] Bayesian concordance: multinma results in supplement (if available)
+
+---
+
+## Comparison: Standard NMA vs CNMA
+
+| Aspect | Standard NMA | CNMA (Additive) | CNMA (Interaction) |
+|---|---|---|---|
+| Treatment model | Each treatment is unique | Treatments = sum of components | Components + interactions |
+| Parameters | One per treatment pair | One per component | Components + interaction terms |
+| Disconnected network | Cannot fit | May reconnect | May reconnect |
+| Assumption | Consistency | Consistency + additivity | Consistency |
+| Key output | League table | Component effects | Component + interaction effects |
+| Package | `netmeta` / `gemtc` | `netmeta::discomb()` | `netmeta::discomb(C.matrix="full")` |
+
+---
+
+## References
+
+- **Rücker G, Petropoulou M, Schwarzer G.** Network meta-analysis of multicomponent interventions. *Biom J.* 2020;62(3):808-821. doi:10.1002/bimj.201800167
+- **Welton NJ, Caldwell DM, Adamopoulos E, Vedhara K.** Mixed treatment comparison meta-analysis of complex interventions: psychological interventions in coronary heart disease. *Am J Epidemiol.* 2009;169(9):1158-1165.
+- **Phillippo DM.** multinma: Bayesian Network Meta-Analysis of Individual and Aggregate Data. R package.
+
+---
+
+## See Also
+
+- [NMA Overview](nma-overview.md) — When to use NMA vs pairwise
+- [NMA R Guide](nma-r-guide.md) — Step-by-step NMA workflow (Steps 11-13 cover CNMA)
+- [NMA Assumptions](nma-assumptions.md) — Transitivity, consistency, homogeneity
+- [NMA Completion Checklist](nma-completion-checklist.md) — Items 26-28 for CNMA

--- a/ma-network-meta-analysis/references/nma-completion-checklist.md
+++ b/ma-network-meta-analysis/references/nma-completion-checklist.md
@@ -196,6 +196,47 @@
 
 ---
 
+## 🧩 **CNMA Extension (If Combination Treatments Present)**
+
+> These items are **conditional** — only required if the network contains combination treatments (e.g., "DrugA+DrugB"). Skip if all treatments are single-component.
+
+- [ ] **26. Component effects estimated**
+  - Additive CNMA model fitted via `discomb()`
+  - Component-level effect estimates with CIs reported
+  - Forest plot of component effects: `figures/cnma_components_additive.png`
+  - **Missing?** Run `nma_11_cnma.R`
+
+- [ ] **27. Interaction test performed and reported**
+  - Additive vs interaction model comparison (Q-test)
+  - p-value reported; interpretation: additive sufficient or interaction present
+  - Interaction test CSV: `tables/cnma_interaction_test.csv`
+  - Model comparison CSV: `tables/cnma_model_comparison.csv`
+  - **Missing?** Run `nma_11_cnma.R`
+
+- [ ] **28. If disconnected network reconnected: additivity assumption discussed**
+  - Results flagged as **sensitivity analysis only**
+  - Clinical plausibility of additivity explicitly discussed
+  - Comparison with vs without disconnected treatments
+  - **Missing?** Check `cnma_report.txt`
+
+---
+
+## 📈 **Advanced Extensions (Optional)**
+
+- [ ] **29. NMA meta-regression (if covariates available)**
+  - Continuous and/or categorical covariates tested via `netmetareg()`
+  - tau² reduction quantified
+  - Bubble plots: `figures/nma_metareg_*.png`
+  - **Missing?** Run `nma_12_meta_regression.R`
+
+- [ ] **30. Statistical transitivity assessment**
+  - Effect modifier distributions compared across comparisons
+  - Traffic light table: `tables/transitivity_tests.csv`
+  - Supplements clinical transitivity table (nma-assumptions.md)
+  - **Missing?** Run `nma_13_transitivity_tests.R`
+
+---
+
 ## ✅ **Completion Criteria**
 
 **Ready to submit if**:

--- a/ma-network-meta-analysis/references/nma-overview.md
+++ b/ma-network-meta-analysis/references/nma-overview.md
@@ -41,11 +41,16 @@ How many treatments?
 ├─ 2 treatments → Standard pairwise MA (ma-meta-analysis)
 └─ ≥3 treatments
    ├─ Are all treatments connected? (shared comparators)
-   │  ├─ No → Cannot do NMA. Consider separate pairwise MAs
+   │  ├─ No → Can CNMA reconnect via shared components?
+   │  │  ├─ Yes → Component NMA (nma_11_cnma.R) — additive model
+   │  │  └─ No → Cannot do NMA. Consider separate pairwise MAs
    │  └─ Yes
    │     ├─ Is transitivity plausible?
    │     │  ├─ No → Discuss limitations; consider sensitivity analyses
    │     │  └─ Yes → Network Meta-Analysis (ma-network-meta-analysis)
+   │     ├─ Do combination treatments exist?
+   │     │  ├─ Yes → Run CNMA extension (nma_11_cnma.R) after standard NMA
+   │     │  └─ No → Standard NMA sufficient
    │     └─ Do you need treatment rankings?
    │        ├─ Yes → NMA with SUCRA rankings (Bayesian)
    │        └─ No → NMA still valid for indirect comparisons
@@ -129,9 +134,37 @@ When `analysis_type: nma` is set in `pico.yaml`:
 
 ---
 
+## CNMA Extension (Combination Therapies)
+
+When your network includes **combination treatments** (e.g., Drug A + Drug B), Component NMA (CNMA) can:
+
+1. **Decompose** combination effects into individual component contributions
+2. **Test interactions** between components (synergy/antagonism)
+3. **Reconnect disconnected networks** by assuming additive component effects
+
+CNMA is run **after** the standard NMA workflow (nma_01–10) as an optional extension using `nma_11_cnma.R`.
+
+- **Frequentist** (primary): `netmeta::discomb()` — the reference implementation
+- **Bayesian** (sensitivity): `multinma::nma()` with component regression
+
+See [CNMA Guide](cnma-guide.md) for detailed decision criteria, data requirements, and reporting.
+
+---
+
+## Advanced Extensions
+
+| Extension | Script | When to Use |
+|---|---|---|
+| Component NMA (CNMA) | `nma_11_cnma.R` | Combination treatments in network |
+| NMA Meta-Regression | `nma_12_meta_regression.R` | Study-level covariates available |
+| Transitivity Testing | `nma_13_transitivity_tests.R` | Always (supplements clinical assessment) |
+
+---
+
 ## Further Reading
 
 - [NMA R Guide](nma-r-guide.md) — Step-by-step Bayesian NMA workflow with gemtc
 - [NMA Assumptions](nma-assumptions.md) — How to assess transitivity and consistency
 - [NMA Reporting Checklist](nma-reporting-checklist.md) — PRISMA-NMA 32-item checklist
 - [Package Comparison](nma-package-comparison.md) — gemtc vs netmeta vs multinma
+- [CNMA Guide](cnma-guide.md) — Component NMA for combination therapies

--- a/ma-network-meta-analysis/references/nma-package-comparison.md
+++ b/ma-network-meta-analysis/references/nma-package-comparison.md
@@ -10,6 +10,7 @@
 | Your Situation | Use This | Why |
 |---------------|----------|-----|
 | **Default NMA (recommended)** | **gemtc** (primary) + **netmeta** (sensitivity) | Bayesian primary per NICE/WHO/Cochrane; frequentist sensitivity in supplement |
+| **CNMA (combination treatments)** | **netmeta::discomb()** (primary) + **multinma** (Bayesian sensitivity) | discomb() is the reference CNMA implementation; multinma adds Bayesian robustness |
 | Need IPD + aggregate data | **multinma** | Modern Stan-based, handles both data types |
 | No JAGS available | **netmeta** only | Fall back to frequentist if JAGS install not possible |
 | Cochrane review | **gemtc** primary | Cochrane Handbook supports Bayesian NMA |
@@ -150,7 +151,7 @@ hn.prior <- mtc.hy.prior("dlnorm", -2.56, 1.74^(-2))
 
 | Feature | gemtc | netmeta | multinma |
 |---------|-------|---------|----------|
-| **Role in pipeline** | **Primary** | **Sensitivity** | Advanced |
+| **Role in pipeline** | **Primary** | **Sensitivity** | Advanced / CNMA Bayesian |
 | Install difficulty | Medium (JAGS) | Easy | Hard (Stan) |
 | Speed | Slow (MCMC) | Fast | Medium |
 | Learning curve | Medium | Low | High |
@@ -159,6 +160,8 @@ hn.prior <- mtc.hy.prior("dlnorm", -2.56, 1.74^(-2))
 | Priors | Turner/Rhodes or vague | N/A | Flexible |
 | Model comparison | DIC | — | LOO-IC |
 | IPD support | No | No | Yes |
+| **CNMA support** | No | **Yes (`discomb()`)** | **Yes (component regression)** |
+| **NMA meta-regression** | No | **Yes (`netmetareg()`)** | Yes |
 | Network visualization | Basic | Excellent | Basic |
 | NICE/WHO alignment | Yes | Partial | Yes |
 | External deps | JAGS | None | Stan |

--- a/ma-network-meta-analysis/references/nma-r-guide.md
+++ b/ma-network-meta-analysis/references/nma-r-guide.md
@@ -313,6 +313,74 @@ net <- netmeta(TE, seTE, treat1, treat2, studlab,
 
 ---
 
+## Step 11: Component NMA (If Combination Treatments Exist)
+
+If your network includes combination treatments (e.g., "DrugA+DrugB"), use CNMA to decompose effects:
+
+```r
+# Frequentist CNMA (primary) — additive model
+cnma_add <- discomb(TE, seTE, treat1, treat2, studlab,
+                    data = nma_data, sm = "RR",
+                    random = TRUE, inactive = "placebo")
+forest(cnma_add)
+
+# Interaction model
+cnma_int <- discomb(TE, seTE, treat1, treat2, studlab,
+                    data = nma_data, sm = "RR",
+                    random = TRUE, inactive = "placebo",
+                    C.matrix = "full")
+
+# Test interaction significance
+q_diff <- cnma_add$Q - cnma_int$Q
+df_diff <- cnma_add$df.Q - cnma_int$df.Q
+p_interaction <- pchisq(q_diff, df = df_diff, lower.tail = FALSE)
+# p > 0.05 → additive model sufficient
+```
+
+**Full template**: `nma_11_cnma.R` | **Guide**: [CNMA Guide](cnma-guide.md)
+
+---
+
+## Step 12: NMA Meta-Regression (If Covariates Available)
+
+Explore heterogeneity sources with study-level covariates:
+
+```r
+# Continuous covariate
+reg <- netmetareg(net_re, ~ mean_age)
+bubble(reg)  # Bubble plot
+
+# Categorical covariate
+reg_cat <- netmetareg(net_re, ~ factor(risk_of_bias))
+
+# Compare tau² reduction
+cat("Baseline tau²:", net_re$tau2, "→ Adjusted:", reg$tau2)
+```
+
+**Full template**: `nma_12_meta_regression.R`
+
+---
+
+## Step 13: Statistical Transitivity Testing
+
+Supplement clinical transitivity assessment with quantitative tests:
+
+```r
+# Compare effect modifier distributions across comparisons
+kruskal.test(mean_age ~ comparison, data = nma_data)
+
+# Meta-regression as transitivity proxy
+# Large tau² changes when adjusting suggest modifier violates transitivity
+reg <- netmetareg(net_re, ~ modifier)
+
+# Direct vs full NMA comparison (Salanti 2012)
+ns <- netsplit(net_re)  # Already run in nma_05
+```
+
+**Full template**: `nma_13_transitivity_tests.R`
+
+---
+
 ## Common Pitfalls
 
 1. **Skipping convergence diagnostics**: Always check Rhat, ESS, and trace plots

--- a/ma-network-meta-analysis/scripts/validate_nma_outputs.py
+++ b/ma-network-meta-analysis/scripts/validate_nma_outputs.py
@@ -326,6 +326,98 @@ def check_sensitivity_analysis(project_root: Path) -> Tuple[bool, List[str]]:
     return True, issues
 
 
+def check_cnma_outputs(project_root: Path) -> Tuple[bool, List[str]]:
+    """Check CNMA outputs (optional — only if CNMA was run)."""
+    issues = []
+
+    # Check if CNMA was run (indicated by cnma_report.txt)
+    cnma_report = project_root / "06_analysis" / "cnma_report.txt"
+
+    if not cnma_report.exists():
+        # CNMA is optional — not an issue if not run
+        return True, ["ℹ️ CNMA not run (no combination treatments or not applicable)"]
+
+    # If CNMA was run, validate outputs
+    # Check component forest plot
+    component_plot = (
+        project_root / "06_analysis" / "figures" / "cnma_components_additive.png"
+    )
+    if not component_plot.exists():
+        issues.append("⚠️ CNMA component forest plot not found")
+
+    # Check interaction test results
+    interaction_csv = (
+        project_root / "06_analysis" / "tables" / "cnma_interaction_test.csv"
+    )
+    if not interaction_csv.exists():
+        issues.append(
+            "⚠️ CNMA interaction test results not found "
+            "(tables/cnma_interaction_test.csv)"
+        )
+
+    # Check model comparison table
+    model_comparison_csv = (
+        project_root / "06_analysis" / "tables" / "cnma_model_comparison.csv"
+    )
+    if not model_comparison_csv.exists():
+        issues.append(
+            "⚠️ CNMA model comparison table not found "
+            "(tables/cnma_model_comparison.csv)"
+        )
+
+    if not issues:
+        issues.append("✅ CNMA outputs complete (component effects + interaction test)")
+
+    return True, issues
+
+
+def check_meta_regression_outputs(project_root: Path) -> Tuple[bool, List[str]]:
+    """Check NMA meta-regression outputs (optional)."""
+    issues = []
+
+    metareg_report = project_root / "06_analysis" / "nma_metareg_report.txt"
+
+    if not metareg_report.exists():
+        return True, ["ℹ️ NMA meta-regression not run (no covariates or not applicable)"]
+
+    # Check regression results
+    metareg_csv = (
+        project_root / "06_analysis" / "tables" / "nma_metareg_results.csv"
+    )
+    if not metareg_csv.exists():
+        issues.append("⚠️ Meta-regression results CSV not found")
+
+    if not issues:
+        issues.append("✅ NMA meta-regression outputs present")
+
+    return True, issues
+
+
+def check_transitivity_tests(project_root: Path) -> Tuple[bool, List[str]]:
+    """Check statistical transitivity assessment outputs (optional)."""
+    issues = []
+
+    transit_report = (
+        project_root / "06_analysis" / "transitivity_assessment_report.txt"
+    )
+
+    if not transit_report.exists():
+        return True, [
+            "ℹ️ Statistical transitivity tests not run "
+            "(ensure clinical assessment in nma-assumptions.md is done)"
+        ]
+
+    # Check traffic light table
+    transit_csv = project_root / "06_analysis" / "tables" / "transitivity_tests.csv"
+    if not transit_csv.exists():
+        issues.append("⚠️ Transitivity test results CSV not found")
+
+    if not issues:
+        issues.append("✅ Statistical transitivity assessment complete")
+
+    return True, issues
+
+
 def generate_validation_report(project_root: Path, strict: bool = False) -> Dict:
     """Generate comprehensive NMA validation report."""
 
@@ -352,6 +444,9 @@ def generate_validation_report(project_root: Path, strict: bool = False) -> Dict
         ("CINeMA GRADE", check_cinema_assessment, [project_root]),
         ("Bayesian convergence", check_bayesian_convergence, [project_root]),
         ("Sensitivity analysis", check_sensitivity_analysis, [project_root]),
+        ("CNMA (component NMA)", check_cnma_outputs, [project_root]),
+        ("NMA meta-regression", check_meta_regression_outputs, [project_root]),
+        ("Transitivity tests", check_transitivity_tests, [project_root]),
     ]
 
     results = {

--- a/ma-topic-intake/references/analysis-type-decision-template.md
+++ b/ma-topic-intake/references/analysis-type-decision-template.md
@@ -74,6 +74,24 @@ Transitivity requires that study populations across different comparisons are si
 
 **Overall transitivity**: Plausible / Uncertain / Implausible
 
+### 2c-bis. CNMA Suitability (If Combination Treatments Exist)
+
+> Complete this section only if the network includes combination therapies (e.g., "ACEI+ARB", "Chemo+Immuno"). Skip if all treatments are single-component.
+
+| Criterion | Value | Notes |
+|-----------|-------|-------|
+| Combination treatments present in network | Yes/No | List: [e.g., ACEI+ARB, Chemo+Immuno] |
+| Components identifiable from treatment labels | Yes/No | Can each treatment be decomposed into named components? |
+| Additivity assumption clinically plausible | Yes/No/Uncertain | Are component effects likely independent? |
+| Disconnected network that CNMA could reconnect | Yes/No | Does standard NMA fail due to disconnection? |
+| ≥3 studies involving combination treatments | Yes/No | Sufficient data for component estimation? |
+
+**CNMA recommendation**: Run nma_11_cnma.R / Skip CNMA
+
+**Rationale**: [1-2 sentences on whether CNMA adds value for this network]
+
+---
+
 ### 2d. Decision Matrix
 
 | Criterion | Threshold | Actual | Pass? |


### PR DESCRIPTION
Integrate three expert-recommended NMA extensions as optional scripts
(nma_11-13) that run after the standard NMA workflow (nma_01-10):

- nma_11_cnma.R: Component NMA via netmeta::discomb() (frequentist primary)
  and multinma (Bayesian sensitivity). Decomposes combination treatments,
  tests interactions, and can reconnect disconnected networks.
- nma_12_meta_regression.R: NMA meta-regression via netmetareg() with
  continuous/categorical covariates and subgroup NMA.
- nma_13_transitivity_tests.R: Statistical transitivity assessment using
  effect modifier distribution tests, meta-regression proxy, and direct
  vs full NMA comparison (Salanti 2012 approach).
- cnma-guide.md: Reference doc covering CNMA concepts, decision criteria,
  data requirements, and reporting checklist.

Updates existing docs: nma-overview, nma-r-guide, nma-completion-checklist,
nma-package-comparison, analysis-type-decision-template, statistician prompt,
end-to-end SKILL, setup script (adds multinma), and validation script.

https://claude.ai/code/session_018PMkTwZHkxuZWhWmYi28EA